### PR TITLE
fixed bug, groups can now have spaces in name

### DIFF
--- a/plugins/modules/groups.py
+++ b/plugins/modules/groups.py
@@ -72,7 +72,7 @@ from ansible.module_utils.six.moves.urllib.parse import quote
 import re
 import fnmatch
 import json
-import urllib
+import ansible.module_utils.six.moves.urllib as url_lib
 
 
 def main():
@@ -98,7 +98,7 @@ def main():
         ]
 
     def get_groups(name: str = module.params['name']):
-        valid_url_name = urllib.parse.quote(name)
+        valid_url_name = url_lib.parse.quote(name)
         return crc_request.get(f'{EDGE_API_GROUPS}?name={valid_url_name}')
 
     def post_group(name):

--- a/plugins/modules/groups.py
+++ b/plugins/modules/groups.py
@@ -72,6 +72,7 @@ from ansible.module_utils.six.moves.urllib.parse import quote
 import re
 import fnmatch
 import json
+import urllib
 
 
 def main():
@@ -97,7 +98,8 @@ def main():
         ]
 
     def get_groups(name: str = module.params['name']):
-        return crc_request.get(f'{EDGE_API_GROUPS}?name={name}')
+        valid_url_name = urllib.parse.quote(name)
+        return crc_request.get(f'{EDGE_API_GROUPS}?name={valid_url_name}')
 
     def post_group(name):
         group_data = {


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
- Added support for groups to have spaces in the name

<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
Fixes #19

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
groups.py

##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below

```
